### PR TITLE
Fix problematic lock renewal after leader failure in Consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ if err != nil {
 }
 
 underwood := leadership.NewCandidate(client, "service/swarm/leader", "underwood", 15*time.Second)
-electedCh, _, err := underwood.RunForElection()
-if err != nil {
-    log.Fatal("Cannot run for election, store is probably down")
-}
+electedCh, _ := underwood.RunForElection()
 
 for isElected := range electedCh {
 	// This loop will run every time there is a change in our leadership
@@ -49,14 +46,13 @@ It is possible to follow an election in real-time and get notified whenever
 there is a change in leadership:
 ```go
 follower := leadership.NewFollower(client, "service/swarm/leader")
-leaderCh, _, err := follower.FollowElection()
-if err != nil {
-    log.Fatal("Cannot follow the election, store is probably down")
-}
+leaderCh, _ := follower.FollowElection()
 for leader := range leaderCh {
 	// Leader is a string containing the value passed to `NewCandidate`.
 	log.Printf("%s is now the leader", leader)
 }
+log.Fatal("Cannot follow the election, store is probably down")
+// Recovery code or exit
 ```
 
 A typical use case for this is to be able to always send requests to the current
@@ -89,10 +85,7 @@ func participate() {
 }
 
 func run(candidate *leadership.Candidate) {
-    electedCh, errCh, err := candidate.RunForElection()
-    if err != nil {
-        return
-    }
+    electedCh, errCh := candidate.RunForElection()
     for {
         select {
         case isElected := <-electedCh:

--- a/candidate_test.go
+++ b/candidate_test.go
@@ -25,8 +25,7 @@ func TestCandidate(t *testing.T) {
 	mockLock.On("Unlock").Return(nil)
 
 	candidate := NewCandidate(kv, "test_key", "test_node", 0)
-	electedCh, _, err := candidate.RunForElection()
-	assert.Nil(t, err)
+	electedCh, _ := candidate.RunForElection()
 
 	// Should issue a false upon start, no matter what.
 	assert.False(t, <-electedCh)

--- a/follower_test.go
+++ b/follower_test.go
@@ -21,8 +21,7 @@ func TestFollower(t *testing.T) {
 	mockStore.On("Watch", "test_key", mock.Anything).Return(mockKVCh, nil)
 
 	follower := NewFollower(kv, "test_key")
-	leaderCh, errCh, err := follower.FollowElection()
-	assert.Nil(t, err)
+	leaderCh, errCh := follower.FollowElection()
 
 	// Simulate leader updates
 	go func() {


### PR DESCRIPTION
This PR changes slightly the lock management during
the leader election process by removing the session
in a best effort fashion after a leader or store
failure.

This is necessary for Consul which restores the session
after the leader failure and leaves the current leader
unaware of its status change, thus leaving the cluster
without leader.

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
